### PR TITLE
Building with gcc: wrap atomics

### DIFF
--- a/mm/llfree/private/platform.h
+++ b/mm/llfree/private/platform.h
@@ -65,6 +65,51 @@ static const int ATOM_LOAD_ORDER = __ATOMIC_ACQUIRE;
 static const int ATOM_UPDATE_ORDER = __ATOMIC_ACQ_REL;
 static const int ATOM_STORE_ORDER = __ATOMIC_RELEASE;
 
+/* GCC compatibility */
+#ifdef __GNUC__
+
+#define __c11_atomic_compare_exchange_strong(obj, expected, desired, order_success, order_failure) \
+	__extension__								\
+	({									\
+		__auto_type __atomic_compare_exchange_ptr = (obj);			\
+		__typeof__ ((void)0, *__atomic_compare_exchange_ptr) __atomic_compare_exchange_tmp \
+			= (desired);								\
+		__atomic_compare_exchange (__atomic_compare_exchange_ptr, (expected),	\
+						 &__atomic_compare_exchange_tmp, 0,	\
+						 (order_success), (order_failure));				\
+	})
+
+#define __c11_atomic_load(obj, order) \
+	__extension__								\
+	({									\
+		__auto_type __atomic_load_ptr = (obj);				\
+		__typeof__ ((void)0, *__atomic_load_ptr) __atomic_load_tmp;			\
+		__atomic_load (__atomic_load_ptr, &__atomic_load_tmp, (order));	\
+		__atomic_load_tmp;							\
+	})
+
+#define __c11_atomic_store(obj, val, order) \
+	__extension__								\
+	({									\
+		__auto_type __atomic_store_ptr = (obj);				\
+		__typeof__ ((void)0, *__atomic_store_ptr) __atomic_store_tmp = (val);	\
+		__atomic_store (__atomic_store_ptr, &__atomic_store_tmp, (order));	\
+	})
+
+#define __c11_atomic_compare_exchange_weak(obj, expected, desired, order_success, order_failure) \
+	__extension__								\
+	({									\
+		__auto_type __atomic_compare_exchange_ptr = (obj);			\
+		__typeof__ ((void)0, *__atomic_compare_exchange_ptr) __atomic_compare_exchange_tmp \
+			= (desired);								\
+		__atomic_compare_exchange (__atomic_compare_exchange_ptr, (expected),	\
+						 &__atomic_compare_exchange_tmp, 1,	\
+						 (order_success), (order_failure));				\
+	})
+
+#endif	/* __GNUC__ */
+
+
 /// Iterates over a Range between multiples of len starting at idx.
 ///
 /// Starting at idx up to the next Multiple of len (exclusive). Then the next


### PR DESCRIPTION
Unlike clang, gcc doesn't provide the `__c11_atomic` builtins.
I have added macros wrapping around them.

In order to actually build everything with gcc, I had to disable `Werror`,
which feels like just a workaround and not a desired change.
That's why I haven't included any further changes here.